### PR TITLE
fix bug: 修复算数型验证码text()取值时产生浮点型结果

### DIFF
--- a/src/main/java/com/wf/captcha/base/ArithmeticCaptchaAbstract.java
+++ b/src/main/java/com/wf/captcha/base/ArithmeticCaptchaAbstract.java
@@ -39,7 +39,7 @@ public abstract class ArithmeticCaptchaAbstract extends Captcha {
         ScriptEngineManager manager = new ScriptEngineManager();
         ScriptEngine engine = manager.getEngineByName("javascript");
         try {
-            chars = String.valueOf(engine.eval(sb.toString().replaceAll("x", "*")));
+            chars = String.valueOf(engine.eval(sb.toString().replaceAll("x", "*"))).split("\\.")[0];
         } catch (ScriptException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
#32 由于engine.eval()方法结果部分是Double，部分是Integer，所以使用强制转换比较麻烦，这里直接对结果进行分隔。
经测试后，算数型验证码不再产生浮点型结果